### PR TITLE
Remove legacy Express-style wildcard log message from workbox artifact

### DIFF
--- a/client/dev-dist/workbox-5a5d9309.js
+++ b/client/dev-dist/workbox-5a5d9309.js
@@ -1158,14 +1158,6 @@ define(['exports'], (function (exports) { 'use strict';
               paramName: 'capture'
             });
           }
-          // We want to check if Express-style wildcards are in the pathname only.
-          // TODO: Remove this log message in v4.
-          const valueToCheck = capture.startsWith('http') ? captureUrl.pathname : capture;
-          // See https://github.com/pillarjs/path-to-regexp#parameters
-          const wildcards = '[*:?+]';
-          if (new RegExp(`${wildcards}`).exec(valueToCheck)) {
-            logger.debug(`The '$capture' parameter contains an Express-style wildcard ` + `character (${wildcards}). Strings are now always interpreted as ` + `exact matches; use a RegExp for partial or wildcard matches.`);
-          }
         }
         const matchCallback = ({
           url


### PR DESCRIPTION
Removed the legacy debug log message regarding Express-style wildcards in the capture parameter which was planned to be removed in v4, from the workbox build artifact (`client/dev-dist/workbox-5a5d9309.js`).

---
*PR created automatically by Jules for task [11483655011653824507](https://jules.google.com/task/11483655011653824507) started by @MohitBansal321*