### PR TITLE
Fix undefined `state` in Workbox plugin callbacks

### DIFF
--- a/client/dev-dist/workbox-5a5d9309.js
+++ b/client/dev-dist/workbox-5a5d9309.js
@@ -1355,10 +1355,7 @@ define(['exports'], (function (exports) { 'use strict';
           request,
           state
         }) => {
-          // TODO: `state` should never be undefined...
-          if (state) {
-            state.originalRequest = request;
-          }
+          state.originalRequest = request;
         };
         this.cachedResponseWillBeUsed = async ({
           event,
@@ -1366,8 +1363,7 @@ define(['exports'], (function (exports) { 'use strict';
           cachedResponse
         }) => {
           if (event.type === 'install') {
-            if (state && state.originalRequest && state.originalRequest instanceof Request) {
-              // TODO: `state` should never be undefined...
+            if (state.originalRequest && state.originalRequest instanceof Request) {
               const url = state.originalRequest.url;
               if (cachedResponse) {
                 this.notUpdatedURLs.push(url);
@@ -2074,7 +2070,7 @@ define(['exports'], (function (exports) { 'use strict';
        * @return {boolean}
        */
       hasCallback(name) {
-        for (const plugin of this._strategy.plugins) {
+        for (const plugin of this._plugins) {
           if (name in plugin) {
             return true;
           }
@@ -2114,7 +2110,7 @@ define(['exports'], (function (exports) { 'use strict';
        * @return {Array<Function>}
        */
       *iterateCallbacks(name) {
-        for (const plugin of this._strategy.plugins) {
+        for (const plugin of this._plugins) {
           if (typeof plugin[name] === 'function') {
             const state = this._pluginStateMap.get(plugin);
             const statefulCallback = param => {


### PR DESCRIPTION
**Context**

In `client/dev-dist/workbox-5a5d9309.js`, `StrategyHandler` correctly copies `strategy.plugins` into `this._plugins` and establishes a state lookup map `this._pluginStateMap` containing state dictionaries associated to those plugin objects.

**Problem**

`StrategyHandler#iterateCallbacks` and `StrategyHandler#hasCallback` incorrectly iterated over the original `this._strategy.plugins`. If plugins were mutated (e.g. `PrecacheInstallReportPlugin` appended during `PrecacheController#install`), iteration yields plugins that were *never present* when `this._pluginStateMap` was populated. 

This causes `this._pluginStateMap.get(plugin)` to evaluate to `undefined`, passing `undefined` as `state` into the plugin method handlers like `handlerWillStart` and `cachedResponseWillBeUsed`.

**Solution**

*   Updated `hasCallback` and `iterateCallbacks` to iterate over `this._plugins`.
*   Removed `TODO` comments.
*   Eliminated defensive checking on `state` inside `handlerWillStart` and `cachedResponseWillBeUsed` as `state` is now guaranteed to exist correctly.

---
*PR created automatically by Jules for task [14332138809735363066](https://jules.google.com/task/14332138809735363066) started by @MohitBansal321*