### PR TITLE
Fix undefined state in Workbox StrategyHandler iterateCallbacks

### DIFF
--- a/client/build/index.html
+++ b/client/build/index.html
@@ -16,8 +16,8 @@
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>Financh — Personal Finance</title>
-    <script type="module" crossorigin src="/assets/index-BHarNs1p.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-IdUU47wT.css">
+    <script type="module" crossorigin src="/assets/index-DBS-tJal.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Bz5c82FP.css">
   <link rel="manifest" href="/manifest.webmanifest"><script id="vite-plugin-pwa:register-sw" src="/registerSW.js"></script></head>
 
   <body>

--- a/client/dev-dist/workbox-5a5d9309.js
+++ b/client/dev-dist/workbox-5a5d9309.js
@@ -1355,7 +1355,6 @@ define(['exports'], (function (exports) { 'use strict';
           request,
           state
         }) => {
-          // TODO: `state` should never be undefined...
           if (state) {
             state.originalRequest = request;
           }
@@ -1367,7 +1366,6 @@ define(['exports'], (function (exports) { 'use strict';
         }) => {
           if (event.type === 'install') {
             if (state && state.originalRequest && state.originalRequest instanceof Request) {
-              // TODO: `state` should never be undefined...
               const url = state.originalRequest.url;
               if (cachedResponse) {
                 this.notUpdatedURLs.push(url);
@@ -2116,7 +2114,11 @@ define(['exports'], (function (exports) { 'use strict';
       *iterateCallbacks(name) {
         for (const plugin of this._strategy.plugins) {
           if (typeof plugin[name] === 'function') {
-            const state = this._pluginStateMap.get(plugin);
+            let state = this._pluginStateMap.get(plugin);
+            if (state === undefined) {
+              state = {};
+              this._pluginStateMap.set(plugin, state);
+            }
             const statefulCallback = param => {
               const statefulParam = Object.assign(Object.assign({}, param), {
                 state


### PR DESCRIPTION
Fixes a TODO in Workbox's `PrecacheInstallReportPlugin` where `state` was unexpectedly undefined. The root cause was `StrategyHandler` not correctly initializing the `state` in `_pluginStateMap` before running the callbacks. This commit updates the generator `iterateCallbacks` to provide a fallback initialization.

---
*PR created automatically by Jules for task [14397522456758416088](https://jules.google.com/task/14397522456758416088) started by @MohitBansal321*