### PR TITLE
Fix Workbox strategy state undefined issue

### DIFF
--- a/client/dev-dist/workbox-5a5d9309.js
+++ b/client/dev-dist/workbox-5a5d9309.js
@@ -2074,7 +2074,7 @@ define(['exports'], (function (exports) { 'use strict';
        * @return {boolean}
        */
       hasCallback(name) {
-        for (const plugin of this._strategy.plugins) {
+        for (const plugin of this._plugins) {
           if (name in plugin) {
             return true;
           }
@@ -2114,7 +2114,7 @@ define(['exports'], (function (exports) { 'use strict';
        * @return {Array<Function>}
        */
       *iterateCallbacks(name) {
-        for (const plugin of this._strategy.plugins) {
+        for (const plugin of this._plugins) {
           if (typeof plugin[name] === 'function') {
             const state = this._pluginStateMap.get(plugin);
             const statefulCallback = param => {

--- a/client/package.json
+++ b/client/package.json
@@ -46,7 +46,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "tailwindcss-animate": "^1.0.7",
-    "vite": "^5.4.0",
+    "vite": "^5.4.21",
     "vite-plugin-pwa": "^1.2.0"
   },
   "scripts": {

--- a/client/patches/workbox-strategies+7.4.1.patch
+++ b/client/patches/workbox-strategies+7.4.1.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/workbox-strategies/StrategyHandler.js b/node_modules/workbox-strategies/StrategyHandler.js
+index 65e2199..f905a85 100644
+--- a/node_modules/workbox-strategies/StrategyHandler.js
++++ b/node_modules/workbox-strategies/StrategyHandler.js
+@@ -372,7 +372,7 @@ class StrategyHandler {
+      * @return {boolean}
+      */
+     hasCallback(name) {
+-        for (const plugin of this._strategy.plugins) {
++        for (const plugin of this._plugins) {
+             if (name in plugin) {
+                 return true;
+             }
+@@ -412,7 +412,7 @@ class StrategyHandler {
+      * @return {Array<Function>}
+      */
+     *iterateCallbacks(name) {
+-        for (const plugin of this._strategy.plugins) {
++        for (const plugin of this._plugins) {
+             if (typeof plugin[name] === 'function') {
+                 const state = this._pluginStateMap.get(plugin);
+                 const statefulCallback = (param) => {


### PR DESCRIPTION
Fixes an issue where `state` is erroneously undefined in `handlerWillStart`. This resolves it by correctly using `this._plugins` in Workbox iterations via patch-package.

---
*PR created automatically by Jules for task [17534467054106136021](https://jules.google.com/task/17534467054106136021) started by @MohitBansal321*